### PR TITLE
FIXED: Whitespaces in source and destination path cause exception.

### DIFF
--- a/typescript-gradle-plugin/build.gradle
+++ b/typescript-gradle-plugin/build.gradle
@@ -39,7 +39,7 @@ javadoc {
 }
 
 group='de.richsource.gradle.plugins'
-version='1.0.5'
+version='1.0.6-SNAPSHOT'
 publishing {
 	publications {
 		mavenJava(MavenPublication) {

--- a/typescript-gradle-plugin/src/main/groovy/de/richsource/gradle/plugins/typescript/CompileTypeScript.groovy
+++ b/typescript-gradle-plugin/src/main/groovy/de/richsource/gradle/plugins/typescript/CompileTypeScript.groovy
@@ -52,10 +52,10 @@ public class CompileTypeScript extends SourceTask {
 		logger.debug("TypeScript files to compile: " + files.join(" "));
 
 		if(outputDir) {
-			tsCompilerArgs.append(" --outDir " + outputDir.toString())
+			tsCompilerArgs.append(" --outDir " + "\"" + outputDir.toString() + "\"")
 		}
 		if(out) {
-			tsCompilerArgs.append(" --out " + out)
+			tsCompilerArgs.append(" --out " + "\"" + out+ "\"")
 		}
 		if(module) {
 			tsCompilerArgs.append(" --module " + module.name().toLowerCase())
@@ -85,10 +85,10 @@ public class CompileTypeScript extends SourceTask {
 			tsCompilerArgs.append(" --sourcemap")
 		}
 		if(sourceRoot) {
-			tsCompilerArgs.append(" --sourceRoot " + sourceRoot)
+			tsCompilerArgs.append(" --sourceRoot " + "\"" + sourceRoot + "\"")
 		}
 		tsCompilerArgs.append(" " + files.join(" "))
-
+		
 		logger.debug("Contents of typescript compiler arguments file: " + tsCompilerArgs.text)
 		
 		String exe = getCompilerExecutableAndArgs().get(0)


### PR DESCRIPTION
The whitespace path problem still persisted because of the "outDir" and other path parameters. 
It should be fixed now. 
I did only check the "default" case when the project path contained whitespaces (not only the source folder).