### PR TITLE
Use correct lifecycle phase to create temp file

### DIFF
--- a/typescript-gradle-plugin/src/main/groovy/de/richsource/gradle/plugins/typescript/CompileTypeScript.groovy
+++ b/typescript-gradle-plugin/src/main/groovy/de/richsource/gradle/plugins/typescript/CompileTypeScript.groovy
@@ -52,11 +52,11 @@ public class CompileTypeScript extends SourceTask {
 	@Input @Optional boolean inlineSourceMap
 	@Input @Optional boolean inlineSources
 	@Input String compilerExecutable = Os.isFamily(Os.FAMILY_WINDOWS) ? "cmd /c tsc.cmd" : "tsc"
-	File tsCompilerArgs = File.createTempFile("tsCompiler-", ".args")
+	File tsCompilerArgs
 
 	@TaskAction
 	void compile() {
-		tsCompilerArgs.deleteOnExit()
+		tsCompilerArgs = File.createTempFile("tsCompiler-",".args")
 		
 		logger.info "compiling TypeScript files..."
 		
@@ -151,6 +151,8 @@ public class CompileTypeScript extends SourceTask {
 			executable = exe
 			args = compilerArgs
 		}
+		
+		tsCompilerArgs.delete()
 		
 		logger.info "Done TypeScript compilation."
 	}


### PR DESCRIPTION
The temp file was being created in the initialization phase, when the CompileTypeScript task is constructed, but it was being designated for deletion during the execution phase. The execution phase may not happen if the task is determined to be up-to-date. This leaves empty compiler documents in the temp folder.

Might as well explicitly delete the file when we’re done with it. If we’re using Gradle daemon, it can take a long time before the JVM exits, and keeping a bunch of files open could lead to interesting failures.